### PR TITLE
Card cover

### DIFF
--- a/src/components/Controls.vue
+++ b/src/components/Controls.vue
@@ -203,6 +203,12 @@
 						<ArrowCollapseVerticalIcon slot="icon" :size="20" decorative />
 						{{ t('deck', 'Toggle compact mode') }}
 					</NcActionButton>
+					<NcActionButton @click="toggleShowCardCover">
+						<template #icon>
+							<ImageIcon :size="20" decorative />
+						</template>
+						{{ showCardCover ? t('deck', 'Hide card cover images') : t('deck', 'Show card cover images') }}
+					</NcActionButton>
 				</NcActions>
 				<!-- FIXME: NcActionRouter currently doesn't work as an inline action -->
 				<NcActions>
@@ -222,6 +228,7 @@ import { NcActions, NcActionButton, NcAvatar, NcButton, NcPopover } from '@nextc
 import labelStyle from '../mixins/labelStyle.js'
 import CardCreateDialog from '../CardCreateDialog.vue'
 import ArchiveIcon from 'vue-material-design-icons/Archive.vue'
+import ImageIcon from 'vue-material-design-icons/ImageMultiple.vue'
 import FilterIcon from 'vue-material-design-icons/Filter.vue'
 import FilterOffIcon from 'vue-material-design-icons/FilterOff.vue'
 import ArrowCollapseVerticalIcon from 'vue-material-design-icons/ArrowCollapseVertical.vue'
@@ -239,6 +246,7 @@ export default {
 		NcAvatar,
 		CardCreateDialog,
 		ArchiveIcon,
+		ImageIcon,
 		FilterIcon,
 		FilterOffIcon,
 		ArrowCollapseVerticalIcon,
@@ -279,6 +287,7 @@ export default {
 		]),
 		...mapState({
 			compactMode: state => state.compactMode,
+			showCardCover: state => state.showCardCover,
 			searchQuery: state => state.searchQuery,
 		}),
 		detailsRoute() {
@@ -336,6 +345,9 @@ export default {
 		toggleShowArchived() {
 			this.$store.dispatch('toggleShowArchived')
 			this.showArchived = !this.showArchived
+		},
+		toggleShowCardCover() {
+			this.$store.dispatch('toggleShowCardCover')
 		},
 		addNewStack() {
 			this.stack = { title: this.newStackTitle }

--- a/src/components/cards/CardCover.vue
+++ b/src/components/cards/CardCover.vue
@@ -1,0 +1,103 @@
+<!--
+  - @copyright Copyright (c) 2023 Johannes Szeibert <johannes@szeibert.de>
+  -
+  - @author Johannes Szeibert <johannes@szeibert.de>
+  -
+  - @license GNU AGPL version 3 or any later version
+  -
+  - This program is free software: you can redistribute it and/or modify
+  - it under the terms of the GNU Affero General Public License as
+  - published by the Free Software Foundation, either version 3 of the
+  - License, or (at your option) any later version.
+  -
+  - This program is distributed in the hope that it will be useful,
+  - but WITHOUT ANY WARRANTY; without even the implied warranty of
+  - MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  - GNU Affero General Public License for more details.
+  -
+  - You should have received a copy of the GNU Affero General Public License
+  - along with this program. If not, see <http://www.gnu.org/licenses/>.
+  -
+  -->
+
+<template>
+	<div v-if="cardId && ( attachments.length > 0 )" class="card-cover">
+		<div v-for="(attachment, index) in attachments"
+			:key="attachment.id"
+			:class="['image-wrapper', { 'rounded-left': index === 0 }, { 'rounded-right': index === attachments.length - 1 }]"
+			:style="{ backgroundImage: `url(${attachmentPreview(attachment)})` }" />
+	</div>
+</template>
+<script>
+import { mapActions } from 'vuex'
+import { generateUrl } from '@nextcloud/router'
+
+export default {
+	name: 'CardCover',
+	props: {
+		cardId: {
+			type: Number,
+			required: true,
+		},
+	},
+	computed: {
+		attachments() {
+			return [...this.$store.getters.attachmentsByCard(this.cardId)]
+				// Filter deleted and hasPreview
+				.filter(attachment => attachment.deletedAt >= 0 && attachment.extendedData.hasPreview)
+				// sort by id (same as in AttachmentList) to get Newest
+				.sort((a, b) => b.id - a.id)
+				// limit to 3 like with android Deck app
+				.slice(0, 3)
+		},
+		attachmentPreview() {
+			// FIXME find a better way to get the stack-width
+			const stackWidth = getComputedStyle(document.documentElement).getPropertyValue('--stack-width').trim()
+			const x = Math.ceil(parseInt(stackWidth) / this.attachments.length) | 260
+			const y = 100
+			return attachment => (
+				// The core preview provider is a bit strange at times, providing much larger than needed images
+				// when cropping is enabled. Therefore use a=1 to not crop the image and let css handle the overflow
+				attachment.extendedData.fileid ? generateUrl(`/core/preview?fileId=${attachment.extendedData.fileid}&x=${x}&y=${y}&a=1`) : null
+			)
+		},
+	},
+	watch: {
+		cardId: {
+			immediate: true,
+			handler() {
+				this.fetchAttachments(this.cardId)
+			},
+		},
+	},
+	methods: {
+		...mapActions([
+			'fetchAttachments',
+		]),
+	},
+}
+</script>
+
+<style lang="scss" scoped>
+@import '../../css/variables';
+.card-cover {
+	height: 100px;
+	display: flex;
+
+	.image-wrapper {
+		flex: 1;
+		position: relative;
+		background-size: cover;
+		background-repeat: no-repeat;
+		background-position: center center;
+
+		&.rounded-left {
+		border-top-left-radius: 10px;
+		}
+
+		&.rounded-right {
+		border-top-right-radius: 10px;
+		}
+	}
+}
+</style>

--- a/src/components/cards/CardItem.vue
+++ b/src/components/cards/CardItem.vue
@@ -34,6 +34,7 @@
 				<div :style="{backgroundColor: '#' + board.color}" class="board-bullet" />
 				{{ board.title }} » {{ stack.title }}
 			</div>
+			<CardCover v-if="showCardCover" :card-id="card.id" />
 			<div class="card-upper">
 				<h3 v-if="inlineEditingBlocked">
 					{{ card.title }}
@@ -90,11 +91,12 @@ import Color from '../../mixins/color.js'
 import labelStyle from '../../mixins/labelStyle.js'
 import AttachmentDragAndDrop from '../AttachmentDragAndDrop.vue'
 import CardMenu from './CardMenu.vue'
+import CardCover from './CardCover.vue'
 import DueDate from './badges/DueDate.vue'
 
 export default {
 	name: 'CardItem',
-	components: { CardBadges, AttachmentDragAndDrop, CardMenu, DueDate },
+	components: { CardBadges, AttachmentDragAndDrop, CardMenu, DueDate, CardCover },
 	directives: {
 		ClickOutside,
 	},
@@ -127,6 +129,7 @@ export default {
 		...mapState({
 			compactMode: state => state.compactMode,
 			showArchived: state => state.showArchived,
+			showCardCover: state => state.showCardCover,
 			currentBoard: state => state.currentBoard,
 		}),
 		...mapGetters([

--- a/src/store/main.js
+++ b/src/store/main.js
@@ -62,6 +62,7 @@ export default new Vuex.Store({
 		showArchived: false,
 		navShown: localStorage.getItem('deck.navShown') === null || localStorage.getItem('deck.navShown') === 'true',
 		compactMode: localStorage.getItem('deck.compactMode') === 'true',
+		showCardCover: localStorage.getItem('deck.showCardCover') === 'true',
 		sidebarShown: false,
 		currentBoard: null,
 		currentCard: null,
@@ -228,6 +229,10 @@ export default new Vuex.Store({
 		toggleCompactMode(state) {
 			state.compactMode = !state.compactMode
 			localStorage.setItem('deck.compactMode', state.compactMode)
+		},
+		toggleShowCardCover(state) {
+			state.showCardCover = !state.showCardCover
+			localStorage.setItem('deck.showCardCover', state.showCardCover)
 		},
 		setBoards(state, boards) {
 			state.boards = boards
@@ -438,6 +443,9 @@ export default new Vuex.Store({
 		},
 		toggleCompactMode({ commit }) {
 			commit('toggleCompactMode')
+		},
+		toggleShowCardCover({ commit }) {
+			commit('toggleShowCardCover')
 		},
 		setCurrentBoard({ commit }, board) {
 			commit('setCurrentBoard', board)


### PR DESCRIPTION
This is a PR for staging only and discussion and will not be merged
-----
* Resolves: #1635
* Target version: stable26

### Summary
This is my simple implementation of card cover images, inspired by the CoverImage feature of deck Android app:

I placed the option alongside compact mode and it enabled/disables the option globaly (even for the upcoming cards view):
![CardCover-option](https://github.com/jszeibert/deck/assets/22236337/135f3280-820c-48d2-b99a-3b58c8dcfa5e)

This is the normal board view, ... 
![CardCover-boardView](https://github.com/jszeibert/deck/assets/22236337/d1a9950d-42a1-4f80-96c4-3e1e30a527d1)

with compact mode I'm deviating from the android app, because if there is a due date and I would add the image to the left of the card (like proposed in https://github.com/nextcloud/deck/pull/2858), ... there isn't very much space left for the card title.
![CardCover-compactView](https://github.com/jszeibert/deck/assets/22236337/c3efff45-e128-4528-b1a4-d4ee109b2d34)

And finaly the mobile view:
![CardCover-mobileView](https://github.com/jszeibert/deck/assets/22236337/4fa5ced4-4a58-48c3-bc84-7141f74cfb7b)

### TODO

- [ ] collect feedback for improvements
- [ ] Tests (unit, integration, api and/or acceptance)
- [ ] add Sign-off message to all commits